### PR TITLE
Fix call to `rlp_memoverlap`

### DIFF
--- a/rlp_serializer.c
+++ b/rlp_serializer.c
@@ -132,7 +132,7 @@ int rlp_encode_element(void *rlpEncodedOutput, size_t rlpEncodedOutputLen, const
     return ERR_RLP_EBADARG;
   if(rlpEncodedOutputLen < (rlpElement->len + 1)) // extra byte for rlp encoding tag
     return ERR_RLP_ENOMEM;
-  if(rlp_memoverlap(rlpEncodedOutput, rlpEncodedOutputLen, rlpElement->buff, rlpElement->len)) // No overlapping memory regions
+  if(rlp_memoverlap(rlpEncodedOutput, rlpElement->len, rlpElement->buff, rlpElement->len)) // No overlapping memory regions
     return ERR_RLP_EILLEGALMEM;
 
   uint8_t *rlpOut = (uint8_t *)rlpEncodedOutput;


### PR DESCRIPTION
Because the address at `rlpEncodedOutput` is getting shifted after every RLP element is encoded, we need to check overlap of the *new* address plus the element size. Previously if a large element got added and the `rlpEncodedOutput` address shifted too much, this check would always fail because we were adding the total buffer size to the updated address.