### PR TITLE
rlp_serializer: fix start ptr offset in memcheck overlap end boundary…

### DIFF
--- a/rlp_serializer.c
+++ b/rlp_serializer.c
@@ -219,7 +219,7 @@ int rlp_encode_list(void *rlpEncodedOutput, size_t rlpEncodedOutputLen,
   
   // Encode each element
   for(int i = 0; i < rplElementsLen; i++) {
-    int ret = rlp_encode_element((rlpOut + rlpEncodedLen), rlpEncodedOutputLen, rlpElementsArr[i]);
+    int ret = rlp_encode_element((rlpOut + rlpEncodedLen), (rlpEncodedOutputLen - rlpEncodedLen), rlpElementsArr[i]);
     DEBUG_PRINTF("retsize == %zu | elementNum == %d\r\n", ret, i);
     if(ret < 0)
       return ret;


### PR DESCRIPTION
… in 'rlp_encode_list'